### PR TITLE
lowercase custom events names

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In your template you can use this syntax:
     id="map" 
     className="form-control"
     placeholder="Start typing"
-    v-on:placeChanged="getFromData"
+    v-on:placechanged="getFromData"
 >
 </vue-google-autocomplete>
 ```
@@ -84,7 +84,7 @@ The input field will get this placeholder text.
 
 ### Example
 
-Please note that you need to provide what method will listen (`v-on:placeChanged`) to an event when the address data is obtained. 
+Please note that you need to provide what method will listen (`v-on:placechanged`) to an event when the address data is obtained. 
 
 ```js
 <template>
@@ -95,7 +95,7 @@ Please note that you need to provide what method will listen (`v-on:placeChanged
             id="map" 
             className="form-control"
             placeholder="Please type your address"
-            v-on:placeChanged="getAddressData"
+            v-on:placechanged="getAddressData"
         >
         </vue-google-autocomplete>
     </div>

--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -73,7 +73,7 @@
                     returnData['longitude'] = place.geometry.location.lng();
 
                     // return returnData object and PlaceResult object
-                    this.$emit('placeChanged', returnData, this.autocomplete.getPlace());
+                    this.$emit('placechanged', returnData, this.autocomplete.getPlace());
                 }
            });
         },


### PR DESCRIPTION
Per https://github.com/vuejs/vue/issues/4044, camel cased event names will (and did for me) cause issues when using in-dom templates. The current code will register the listener on the placeChanged event but it will never be called.
 Kebab case would also work. Let me know if that's preferable and I'll update, I just feel that I've seen more smashed together lowercase in updated modules