### PR TITLE
Add input type

### DIFF
--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -1,5 +1,6 @@
 <template>
     <input
+        type="text"
         :class="classname"
         :id="id"
         :placeholder="placeholder"


### PR DESCRIPTION
I'm using [Milligram](http://milligram.io/forms.html) which styles inputs depending on their type attribute.

Is there a reason the type should not be set?