### PR TITLE
Allow for empty types

### DIFF
--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -65,6 +65,12 @@
         },
 
         mounted: function() {
+          const options = {};
+
+          if (this.types) {
+            options.types = [this.types]
+          }
+
           const options = {
             types: [this.types]
           };

--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -68,13 +68,9 @@
           const options = {};
 
           if (this.types) {
-            options.types = [this.types]
+            options.types = [this.types];
           }
-
-          const options = {
-            types: [this.types]
-          };
-
+          
           if (this.country) {
             options.componentRestrictions = {
               country: this.country


### PR DESCRIPTION
I need to allow types to be empty to search both an address and establishments.

As you can see in the Google API docs, if types is empty, Google will search both addresses and establishments. Currently we send an empty array in types, which breaks this functionality.

https://developers.google.com/places/supported_types#table3

With this PR, you can set types to be empty (as shown below) and it will search both an address and establishment. Obviously you can still set it to be "address", "establishment" or "geocode".

```js
<vue-google-autocomplete
                    id="map"
                    classname="input"
                    placeholder="Start typing"
                    types=""
                    v-on:placechanged="getAddressData"
                    country="fr"
                >
```

Thanks for the component !