### PR TITLE
Adding a watcher on inputChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,11 @@ Gets triggered when the autocomplete input field receives focus.
 #### blur
 Gets triggered when the autocomplete input field loses focus.
 
+#### inputChange
+Gets triggered every time autocomplete input got changed
+
 #### change
-Gets triggered when the autocomplete input got changed
+Gets triggered when the autocomplete results got changed
 
 #### keypress
 Gets triggered when a key gets pressed
@@ -199,4 +202,3 @@ Please note that you need to provide what method will listen (`v-on:placechanged
     }
 </script>
 ```
-

--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -64,6 +64,12 @@
             }
         },
 
+        watch: {
+            autocompleteText: function (newVal, oldVal) {
+	            this.$emit('inputChange', { newVal, oldVal });
+            }
+        },
+
         mounted: function() {
           const options = {};
 


### PR DESCRIPTION
Please consider adding an input watcher.
In my use case I need to edit the `pac-items` after every update. Since google-places-autocomplete doesn't have a `debounce` or `throttle`, the only way is by editing the `pac-items` manually, which is not possible without watching the input.

- I've also edited documentation for `change` as it only fires once when the results have updated, not every time the input is changed.

- Additionally, `keypress` just passes the key that was pressed, not very convenient if care about what the entire string is.

Thanks for the repo, very useful!