### PR TITLE
Made the Input inherit all attrs

### DIFF
--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -1,5 +1,6 @@
 <template>
     <input
+        v-bind="$attrs"
         ref="autocomplete"
         type="text"
         :class="classname"
@@ -31,6 +32,8 @@
 
     export default {
         name: 'VueGoogleAutocomplete',
+
+        inheritAttrs: false,
 
         props: {
           id: {


### PR DESCRIPTION
Using tip from https://youtu.be/7lpemgMhi0k?t=21m49s

All the attrs that you give to vue-google-autocomplete component are passed to the input in the field.

```pug
vue-google-autocomplete(:data-some-attr="myVar")
```
becomes
```
<div>
    <input .... data-some-attr="myValue">
</div>
```