### PR TITLE
Fix missing county in address results

### DIFF
--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -20,7 +20,7 @@
         route: 'long_name',
         locality: 'long_name',
         administrative_area_level_1: 'short_name',
-        administrative_area_level_2: 'county',
+        administrative_area_level_2: 'long_name',
         country: 'long_name',
         postal_code: 'short_name'
     };


### PR DESCRIPTION
The `ADDRESS_COMPONENTS `object is a map of `type` to `long_name` or `short_name`, which is used to lookup the actual value.

Before:

```json
{
  "street_number": "1",
  "route": "City Hall Square",
  "locality": "Boston",
  "administrative_area_level_1": "MA",
  "country": "United States",
  "postal_code": "02201",
  "latitude": 42.3602752,
  "longitude": -71.0579295
}
```

After:

```json
{
  "street_number": "1",
  "route": "City Hall Square",
  "locality": "Boston",
  "administrative_area_level_2": "Suffolk County",
  "administrative_area_level_1": "MA",
  "country": "United States",
  "postal_code": "02201",
  "latitude": 42.3602752,
  "longitude": -71.0579295
}