### PR TITLE
Added the option to specify which fields to fetch in the PlaceResult object

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ I have tried to use different Vue Google Autocomplete components, but did not fi
 * Load more than one autocompletion inputs (I could not achieve this with existing vue components)
 * Getting geolocation data (latitude, longitude) for found address object along with other address data (country, city, state, county, street, house number, zip code). So no need to do additional geocode request on backend side.
 * No external dependencies
-* You can get access to underlying [PlaceResult object](https://developers.google.com/maps/documentation/javascript/reference#PlaceResult) to get more details about found location.
+* You can get access to underlying [PlaceResult object](https://developers.google.com/maps/documentation/javascript/reference#PlaceResult) to get more details about found location. You are able to specify the specific fields you want to fetch from the PlaceResult object.
 * You can limit results to specific country or use users geolocation data
 
 ## Installation
@@ -92,6 +92,15 @@ Default: `address`
 Types supported in place autocomplete requests. [More info](https://developers.google.com/places/supported_types#table3)
 
 You may find [this example](#correct-usage-of-the-types-parameter) helpful.
+
+
+#### fields
+Type: `Array`
+Default: `['address_components', 'adr_address', 'alt_id', 'formatted_address', 'geometry', 'icon', 'id', 'name', 'permanently_closed', 'photo', 'place_id', 'scope', 'type', 'url', 'utc_offset', 'vicinity']`
+
+Set which data fields to return in the PlaceResult from the Google Autocomplete API when the user selects a place. [Google Autocomplete API by default returns all available data fields](https://developers.google.com/maps/documentation/javascript/places-autocomplete#get_place_information) for the selected place, which may result in additional charges and thus the API users might pay for data they don't need. This package sets a sensible default for the fields value, fetching only the Basic Data fields which do not result in any additional charges. If you want to fetch other fields in addition to the default ones, make sure that the array you pass in to the `fields` prop contains the default fields listed above, and not only the additional fields you want to fetch.
+
+Refer to [this page](https://developers.google.com/maps/billing/understanding-cost-of-use#data-skus) for more details on how certain data fields are billed.
 
 #### country
 Type: `String`|`Array`

--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -30,6 +30,17 @@
     const REGIONS_TYPE = ['locality', 'sublocality', 'postal_code', 'country',
         'administrative_area_level_1', 'administrative_area_level_2'];
 
+    /*
+      By default, we're only including basic place data because requesting these 
+      fields place data is not additionally charged by Google. Please refer to:
+
+      https://developers.google.com/maps/billing/understanding-cost-of-use#basic-data
+    */
+    const BASIC_DATA_FIELDS = ['address_components', 'adr_address', 'alt_id', 
+        'formatted_address', 'geometry', 'icon', 'id', 'name', 
+        'permanently_closed', 'photo', 'place_id', 'scope', 'type', 'url', 
+        'utc_offset', 'vicinity'];
+
     export default {
         name: 'VueGoogleAutocomplete',
 
@@ -49,6 +60,13 @@
           types: {
             type: String,
             default: 'address'
+          },
+
+          fields: {
+            type: Array,
+            default: function() {
+              return BASIC_DATA_FIELDS;
+            },
           },
 
           country: {
@@ -136,6 +154,8 @@
                 document.getElementById(this.id),
                 options
             );
+
+          this.autocomplete.setFields(this.fields);
 
           this.autocomplete.addListener('place_changed', this.onPlaceChanged);
         },


### PR DESCRIPTION
Since July 16th 2018, Google has introduced changes to it's billing system for it's APIs. This affected the Google Places API considerably. For example, [previously the Places API had 150.000 free requests per day](https://developers.google.com/maps/previous-pricing) whereas now the price can be [around 3$ USD per 1000 requests](https://cloud.google.com/maps-platform/pricing/sheet/).

Still, there's even additional charges that are enabled _by default_, so in order to not get charged for data you might not be using at all (but you've been fetching it before because it was free), now you have to specify what fields you want to fetch:

![image](https://user-images.githubusercontent.com/8971846/48354700-9be6ad80-e692-11e8-9f7a-3085e13c23c3.png)

Additional charges relate to fetching[ Contact Data (phone numbers, opening hours of places)](https://developers.google.com/maps/billing/understanding-cost-of-use#contact-data) or [Atmosphere Data (rating, reviews of a place) ](https://developers.google.com/maps/billing/understanding-cost-of-use#atmosphere-data) among other things. The atmosphere and contact data is fetched by default by the Autocomplete API, together with [Basic Data which is free of charge](https://developers.google.com/maps/billing/understanding-cost-of-use#basic-data) and which should cover many simple use cases.

This PR adds a simple `fields` prop, which by default, only includes Basic Data fields for a place. Users who want to fetch additional data need to specify **all the fields they want to fetch** inside this prop. The PR purposefully disallows passing in a `null` prop so it forces the user to make sure the fields being fetched fit the use-case so that no additional billing happens unintentionally. 

This prop is then passed to the Google's `autocomplete` object by using the [Autocomplete.setFields](https://developers.google.com/maps/documentation/javascript/reference/places-widget#Autocomplete.setFields) method.