### PR TITLE
add bounds prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 mix-manifest.json
 example/dist
+/.project

--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ Default: `{}`
 
 Allow to configure Options for [`navigator.getCurrentPosition`](https://developer.mozilla.org/en/docs/Web/API/Geolocation/getCurrentPosition)
 
+#### bounds
+Type: [`Object`](https://developer.mozilla.org/en/docs/Web/API/PositionOptions)
+Default: `{}`
+
+Define a circle to which search results will be baised.  
+
+```html
+bounds={lat: 45.125, lng: -122.658, radius: 75000} // radius is in meters
+```
+
+
 ### Events
 The component emits next events, which you can listen in your application:
 

--- a/README.md
+++ b/README.md
@@ -118,14 +118,15 @@ Allow to configure Options for [`navigator.getCurrentPosition`](https://develope
 
 #### bounds
 Type: [`Object`](https://developer.mozilla.org/en/docs/Web/API/PositionOptions)
-Default: `{}`
+Default: null
 
-Define a circle to which search results will be baised.  
+Define a circle within which search results will be baised.  
 
 ```html
-bounds={lat: 45.125, lng: -122.658, radius: 75000} // radius is in meters
+<vue-google-autocomplete :bounds="{lat: 45.125, lng: -122.658, radius: 75000}">  <vue-google-autocomplete>
 ```
 
+Will bound results to a circle 150km in diameter centered at 45.125, -122.658.  If no results are found in these bounds, google searches outside it.
 
 ### Events
 The component emits next events, which you can listen in your application:

--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -307,7 +307,6 @@
                         center: {lat: this.bounds['lat'], lng: this.bounds['lng']},
                         radius: this.bounds['radius']
                     });
-                    console.log(circle.getBounds())
                     this.autocomplete.setBounds(circle.getBounds());
 
                 }

--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -55,7 +55,12 @@
             type: [String, Array],
             default: null
           },
-
+        
+          bounds: {
+            type: Object,
+            default: null
+          },
+          
           enableGeolocation: {
             type: Boolean,
             default: false
@@ -297,6 +302,14 @@
                         });
                         this.autocomplete.setBounds(circle.getBounds());
                     })
+                } else if (this.bounds != null){
+                    let circle = new google.maps.Circle({
+                        center: {lat: this.bounds['lat'], lng: this.bounds['lng']},
+                        radius: this.bounds['radius']
+                    });
+                    console.log(circle.getBounds())
+                    this.autocomplete.setBounds(circle.getBounds());
+
                 }
             },
 


### PR DESCRIPTION
The bounds prop allows search results to be biased to a circle, rather than the navigator's current position which is currently the only otion