### PR TITLE
Add search within a radius around a geopoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Note: this is a dynamic property. You must pass it as `:country=""` to your comp
 ```
 will restrict the countries to Australia and New Zealand.
 
+#### boundaries
+Type: `Object`
+Default: null
+
+Allow you to search addresses within a radius around a geopoint
+```html
+<vue-google-autocomplete :boundaries="{lat: 50.848227,lng:4.352601,radius:8000 }"></vue-google-autocomplete>
+```
+will restrict the search 8KM around Brussels in Belgium if the country prop is set to "be" for Belgium.
+
 #### enable-geolocation
 Type: `Boolean`
 Default: `false`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ I have tried to use different Vue Google Autocomplete components, but did not fi
 * No external dependencies
 * You can get access to underlying [PlaceResult object](https://developers.google.com/maps/documentation/javascript/reference#PlaceResult) to get more details about found location.
 * You can limit results to specific country or use users geolocation data
+* You can limit results to specific addresses in a radius around a city
 
 ## Installation
 
@@ -240,6 +241,29 @@ Please note that you need to provide what method will listen (`v-on:placechanged
     }
 </script>
 ```
+
+### Example (eg: restrict the search 8KM around Brussels (Belgium)
+
+```html
+<template>
+    <div>
+        <h2>Your Address</h2>
+
+        <vue-google-autocomplete
+            ref="address"
+            id="map"
+            classname="form-control"
+            placeholder="Please type your address"
+            v-on:placechanged="getAddressData"
+            country="be"
+            :boundaries="{lat: 50.848227,lng:4.352601,radius:8000 }"
+        >
+        </vue-google-autocomplete>
+    </div>
+</template>
+
+```
+
 
 #### Correct usage of the types parameter
 

--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -64,6 +64,11 @@
           geolocationOptions: {
             type: Object,
             default: null
+          },
+	  
+          boundaries: {
+            type: Object,
+            default: null
           }
         },
 
@@ -125,7 +130,9 @@
           if (this.types) {
             options.types = [this.types];
           }
-
+ 	  if(this.boundaries != null){
+            options.strictBounds = true;
+ 	  }
           if (this.country) {
             options.componentRestrictions = {
               country: this.country
@@ -136,6 +143,15 @@
                 document.getElementById(this.id),
                 options
             );
+	    
+	    if(this.boundaries != null ){
+                var LatLngCenter = new google.maps.LatLng(parseFloat(this.boundaries.lat),parseFloat(this.boundaries.lng));
+                var circleBounds =new google.maps.Circle({
+                    center:LatLngCenter,
+                    radius:this.boundaries.radius
+                });
+                this.autocomplete.setBounds(circleBounds.getBounds());
+            }
 
           this.autocomplete.addListener('place_changed', this.onPlaceChanged);
         },


### PR DESCRIPTION
Allow the user to search within a radius around a geopoint.

```sh
eg: Let say you want to list all addresses 8KM around Brussels
- Country : Belgium
- City : Brussels {lat: 50.848227,lng:4.352601}
- Radius : 8KM
```
To list all addresses 8KM around Brussels*:
```sh
:boundaries="{lat: 50.848227,lng:4.352601,radius:8000 }"
```

*if the country is set to Belgium