### PR TITLE
Changed default value for type field

### DIFF
--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -48,7 +48,7 @@
 
           types: {
             type: String,
-            default: 'address'
+            default: ''
           },
 
           country: {


### PR DESCRIPTION
Hello. I found an important issue about search some objects. By default, field 'type' have value 'address' but it hides some results like point of interest and another. Let we set this field to empty string and will to have all search results from Google autocomplete service.