### PR TITLE
Switch types default to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ The input field will get this placeholder text.
 
 #### types
 Type: `String`
-Default: `address`
+Default: `null`
 
 Types supported in place autocomplete requests. [More info](https://developers.google.com/places/supported_types#table3)
 
 You may find [this example](#correct-usage-of-the-types-parameter) helpful.
+
+If nothing is specified, all types are returned.
 
 #### country
 Type: `String`|`Array`

--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -48,7 +48,7 @@
 
           types: {
             type: String,
-            default: 'address'
+            default: null
           },
 
           country: {


### PR DESCRIPTION
There is no way no return all results from google except not provide types at all. So i change default of types prop to null.