### PR TITLE
Update types when changed (#144)

### DIFF
--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -116,6 +116,9 @@
               this.autocomplete.setComponentRestrictions({
                 country: this.country === null ? [] : this.country
               });
+            },
+            types: function(newVal, oldVal) {
+              this.autocomplete.setTypes([this.types]);
             }
         },
 


### PR DESCRIPTION
Currently, the types are only set upon mount and not updated when they change (#144). This resolves that by calling `setTypes()` on the `autocomplete` object when the types prop is updated.