### PR TITLE
trigger place search on blur

### DIFF
--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -173,7 +173,7 @@
             onPlaceChanged() {
                 let place = this.autocomplete.getPlace();
 
-                if (!place.geometry) {
+                if (!place || !place.geometry) {
                   // User entered the name of a Place that was not suggested and
                   // pressed the Enter key, or the Place Details request failed.
                   this.$emit('no-results-found', place, this.id);
@@ -202,6 +202,7 @@
              * When the input loses focus
              */
             onBlur() {
+              google.maps.event.trigger(this.autocomplete, 'place_changed');
               this.$emit('blur');
             },
 


### PR DESCRIPTION
Fixes [no-results-found event should also work on blur event](https://github.com/olefirenko/vue-google-autocomplete/issues/152)