### PR TITLE
Adds a "boundLimits" prop that adds AutocompletionRequest.bounds option to the api request

### DIFF
--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -75,6 +75,11 @@
             },
           },
 
+          boundLimits: {
+            type: Object,
+            default: null
+          },
+
           country: {
             type: [String, Array],
             default: null
@@ -134,7 +139,7 @@
 
         watch: {
             autocompleteText: function (newVal, oldVal) {
-	            this.$emit('inputChange', { newVal, oldVal }, this.id);
+                this.$emit('inputChange', { newVal, oldVal }, this.id);
             },
             country: function(newVal, oldVal) {
               this.autocomplete.setComponentRestrictions({
@@ -152,8 +157,15 @@
 
           if (this.country) {
             options.componentRestrictions = {
-              country: this.country
+              country: this.country,
             };
+          }
+
+          if (this.boundLimits) {
+            var southWest = new google.maps.LatLng(this.boundLimits.sw.lat, this.boundLimits.sw.lon );
+            var northEast = new google.maps.LatLng( this.boundLimits.ne.lat, this.boundLimits.ne.lon);
+            var bounds = new google.maps.LatLngBounds( southWest, northEast );
+            options.bounds = bounds;  
           }
 
           this.autocomplete = new google.maps.places.Autocomplete(

--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -79,6 +79,10 @@
             type: Object,
             default: null
           },
+          /*
+          Example: 
+          :boundLimits="{sw:{lat:60.096670, lon:24.583181}, ne:{lat:60.391643, lon:25.214419}}"
+          */
 
           country: {
             type: [String, Array],


### PR DESCRIPTION
We needed to narrow down the area of our autocomplete searches.

Needs the lower left (South-West) and upper right (North-East) point coordinates of the bounding rectangle.

Example use in the component:
```
<vue-google-autocomplete
:boundLimits="{sw:{lat:60.096670, lon:24.583181}, ne:{lat:60.391643, lon:25.214419}}"
...
/>
```

https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest.bounds